### PR TITLE
Added responsive image to top media

### DIFF
--- a/config/install/field.field.node.stanford_news.field_s_news_top_media.yml
+++ b/config/install/field.field.node.stanford_news.field_s_news_top_media.yml
@@ -5,6 +5,7 @@ dependencies:
     - field.storage.node.field_s_news_top_media
     - node.type.stanford_news
     - paragraphs.paragraphs_type.stanford_paragraph_hero_banner
+    - paragraphs.paragraphs_type.stanford_responsive_image
     - paragraphs.paragraphs_type.stanford_video
   module:
     - entity_reference_revisions
@@ -23,6 +24,7 @@ settings:
   handler_settings:
     target_bundles:
       stanford_paragraph_hero_banner: stanford_paragraph_hero_banner
+      stanford_responsive_image: stanford_responsive_image
       stanford_video: stanford_video
     target_bundles_drag_drop:
       stanford_buttons:
@@ -103,6 +105,9 @@ settings:
       stanford_tall_filmstrip:
         weight: 55
         enabled: false
+      stanford_responsive_image:
+        enabled: true
+        weight: 56
       stanford_tall_slide:
         weight: 56
         enabled: false

--- a/stanford_news.features.yml
+++ b/stanford_news.features.yml
@@ -1,1 +1,2 @@
+bundle: Stanford
 required: true

--- a/stanford_news.info.yml
+++ b/stanford_news.info.yml
@@ -1,9 +1,7 @@
 name: 'Stanford News'
-type: module
 description: 'Stanford news items and views.'
+type: module
 core: 8.x
-package: Stanford
-version: 8.x-1.0-dev
 dependencies:
   - allowed_formats
   - datetime
@@ -21,10 +19,14 @@ dependencies:
   - pathauto
   - rdf
   - scheduler
+  - stanford_news
   - stanford_page
   - stanford_paragraph_hero_banner
+  - stanford_paragraph_responsive_image
   - stanford_paragraph_video
   - stanford_research_area
   - taxonomy
   - text
   - user
+version: 8.x-1.0-dev
+package: Stanford

--- a/stanford_news.info.yml
+++ b/stanford_news.info.yml
@@ -19,7 +19,6 @@ dependencies:
   - pathauto
   - rdf
   - scheduler
-  - stanford_news
   - stanford_page
   - stanford_paragraph_hero_banner
   - stanford_paragraph_responsive_image

--- a/stanford_news.module
+++ b/stanford_news.module
@@ -17,6 +17,9 @@ function stanford_news_panels_build_alter(array &$build, PanelsDisplayVariant $p
   switch ($config['storage_id']) {
     case 'node:stanford_news:full:default':
       $dom = new DOMDocument();
+      // Disable error reports since <picture> tag throws errors.
+      // @see https://stackoverflow.com/questions/6090667/php-domdocument-errors-warnings-on-html5-tags
+      libxml_use_internal_errors(TRUE);
       $dom->loadHTML(render($build['hero']));
 
       // If the hero region has a _populated_ h1 tag, we dont want to render
@@ -24,9 +27,9 @@ function stanford_news_panels_build_alter(array &$build, PanelsDisplayVariant $p
       $h1_tags = $dom->getElementsByTagName('h1');
       if ($h1_tags->length && $h1_tags->item(0)->nodeValue && !empty($build['first'])) {
         // Find the node title block and unset it.
-        foreach($build['first'] as $uuid => $block){
-          if(is_array($block) && isset($block['#plugin_id']) && $block['#plugin_id'] == 'stanford_layouts_node_title'){
-           unset($build['first'][$uuid]);
+        foreach ($build['first'] as $uuid => $block) {
+          if (is_array($block) && isset($block['#plugin_id']) && $block['#plugin_id'] == 'stanford_layouts_node_title') {
+            unset($build['first'][$uuid]);
           }
         }
       }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added responsive image to top media
- Silence errors for dom document.

# Needed By (Date)
- 8/24

# Urgency
- Medium

# Steps to Test

1. Checkout branch
2. revert this feature
3. create news item with a responsive image top media.
4. verify looks.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)