### PR TITLE
Fixed earth matters navigation after pattern was refactored

### DIFF
--- a/modules/stanford_news_earth_matters/config/install/views.view.earth_matters_listing.yml
+++ b/modules/stanford_news_earth_matters/config/install/views.view.earth_matters_listing.yml
@@ -52,7 +52,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/stanford_news_earth_matters/css/stanford_news_earth_matters.css
+++ b/modules/stanford_news_earth_matters/css/stanford_news_earth_matters.css
@@ -1,37 +1,45 @@
-.earth-matters-listing.news-list .js-form-type-select {
+.section-earth-matters .js-form-type-select {
   display: none;
 }
 
-.earth-matters-listing.news-list .form-submit {
+.section-earth-matters .form-submit {
   display: none;
 }
 
-.earth-matters-listing.news-list ul.nav-items {
+.section-earth-matters ul.nav-items {
   display: table;
   margin: 0 auto;
 }
 
-.earth-matters-listing.news-list .nav-item {
+.section-earth-matters ul.nav-items li {
   display: table-cell;
   vertical-align: middle;
 }
 
-.earth-matters-listing.news-list .nav-item.active {
+.section-earth-matters ul.nav-items li.active {
+  background-color: #017c92;
+}
+
+.section-earth-matters ul.nav-items li.active a {
+  color: white;
+}
+
+.section-earth-matters .nav-item.active {
   background-color: #017c92;
   color: white;
 }
 
-.earth-matters-listing.news-list ul.pager {
+.section-earth-matters ul.pager {
   background: #dad7cb;
   padding: 0;
   margin: 0;
 }
 
-.earth-matters-listing.news-list ul.pager .pager__item {
+.section-earth-matters ul.pager .pager__item {
   width: 100%;
 }
 
-.earth-matters-listing.news-list ul.pager a {
+.section-earth-matters ul.pager a {
   display: table;
   padding: 20px;
   color: #fff;

--- a/modules/stanford_news_earth_matters/js/stanford_news_earth_matters.js
+++ b/modules/stanford_news_earth_matters/js/stanford_news_earth_matters.js
@@ -94,7 +94,7 @@
 
         $(element).on('click', function (e) {
           e.preventDefault();
-          $(this).toggleClass('active');
+          $(this).parent().toggleClass('active');
 
           var tid = $(this).attr('data-tid');
           if (!tid) {
@@ -137,7 +137,7 @@
       $.each(Drupal.views.instances, function (i, view) {
         if (view.settings.view_args) {
           $.each(view.settings.view_args.split('+'), function (j, value) {
-            $('a[data-tid="' + value + '"]').addClass('active');
+            $('a[data-tid="' + value + '"]').parent().addClass('active');
             $('a[rel="' + value + '"]').addClass('active');
           })
         }

--- a/modules/stanford_news_earth_matters/scss/stanford_news_earth_matters.scss
+++ b/modules/stanford_news_earth_matters/scss/stanford_news_earth_matters.scss
@@ -1,5 +1,4 @@
-// Hide select form elements to allow js to do the work.
-.earth-matters-listing.news-list {
+.section-earth-matters {
 
   .js-form-type-select {
     display: none;
@@ -12,16 +11,25 @@
   ul.nav-items {
     display: table;
     margin: 0 auto;
+
+    li {
+      display: table-cell;
+      vertical-align: middle;
+
+      &.active {
+        background-color: #017c92;
+
+        a {
+          color: white;
+        }
+      }
+    }
   }
 
-  .nav-item {
-    display: table-cell;
-    vertical-align: middle;
-
-    &.active {
-      background-color: #017c92;
-      color: white;
-    }
+  // No JS backup.
+  .nav-item.active {
+    background-color: #017c92;
+    color: white;
   }
 
   ul.pager {
@@ -40,9 +48,7 @@
       margin: 0 auto;
     }
   }
-}
 
-.section-earth-matters {
   .main-container {
     padding: 0;
   }
@@ -52,11 +58,11 @@
   }
 
   #hero-banner {
-    margin-top:-122px;
+    margin-top: -122px;
   }
 
   .hero-banner__footer {
-    display:none;
+    display: none;
   }
 }
 

--- a/modules/stanford_news_earth_matters/stanford_news_earth_matters.module
+++ b/modules/stanford_news_earth_matters/stanford_news_earth_matters.module
@@ -6,6 +6,8 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\views\ViewExecutable;
+use Drupal\Core\Url;
+use Drupal\Core\Link;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -55,13 +57,22 @@ function stanford_news_earth_matters_form_views_exposed_form_alter(&$form, FormS
 
   $topics_links = [];
   foreach ($topics as $tid => $term_name) {
-    $href = '/earth-matters/' . _stanford_news_earth_matters_clean_name($term_name);
-    if ($tid == 'All') {
-      $topics_links[]['#markup'] = '<a href="" class="filter-tab nav-item active" data-tid="' . $tid . '">' . $term_name . '</a>';
+
+    $path_params = ['term1' => _stanford_news_earth_matters_clean_name($term_name)];
+    $options = [
+      'attributes' => ['class' => ['filter-tab'], 'data-tid' => $tid],
+    ];
+
+    if (in_array($tid, $tids)) {
+      $options['attributes']['class'][] = 'active';
     }
-    else {
-      $topics_links[]['#markup'] = '<a class="filter-tab nav-item" href="' . $href . '" data-tid="' . $tid . '">' . $term_name . '</a>';
-    }
+
+    $url = Url::fromRoute('stanford_news_earth_matters.1_terms', $path_params, $options);
+
+    $topics_links[] = [
+      'name' => $term_name,
+      'link' => Link::fromTextAndUrl(t($term_name), $url)->toString(),
+    ];
   }
 
   // Create the item-list the form should render.
@@ -70,6 +81,7 @@ function stanford_news_earth_matters_form_views_exposed_form_alter(&$form, FormS
     '#id' => 'collapsible_menu',
     '#fields' => ['title' => t('Topics'), 'items' => $topics_links],
   ];
+
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Refactor on collapsible menu broke the earth matters navigation. this fixes that.

# Needed By (Date)
- asap

# Urgency
- high

# Steps to Test

1. checkout branch
2. clear cache
3. review earth-matters page to verify the navigation shows.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)