### PR TITLE
EARTH-932: Ensure masony layout gets called.

### DIFF
--- a/modules/stanford_news_earth_matters/js/stanford_news_earth_matters.js
+++ b/modules/stanford_news_earth_matters/js/stanford_news_earth_matters.js
@@ -8,7 +8,7 @@
   Drupal.behaviors.EarthMatters = {
     attach: function (context, settings) {
 
-      var view = $('.earth-matters-listing.news-list');
+      var view = $('.earth-matters-listing.news-list', context);
 
       /**
        * Set the view filter value in the select.
@@ -85,6 +85,7 @@
           }
           settings.views.ajaxViews['views_dom_id:' + dom_id].view_args = args;
           $(selector).triggerHandler('RefreshView');
+          $(selector).masonry('layout');
         });
       }
 
@@ -162,6 +163,7 @@
         }
       });
     }
+
   };
 
   $(document).ajaxComplete(Drupal.behaviors.EarthMatters.setActives);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix for the overlapping cards after clicking views load more or any ajax event for that matter.

# Needed By (Date)
- ?

# Urgency
- ?

# Steps to Test

1. Load up the earth matters page in your browser on local
2. Resize your browser to something around a tablet size
3. Click on the load more button on the bottom of the page until you get overlapping items
4. Check out this branch
5. Clear caches and refresh earth matters page
6. Click on the load more button until there is nothing left to load while checking for overlaps.

# Affected Projects or Products
- ?

# Associated Issues and/or People
- EARTH-932
- @buttonwillowsix 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)